### PR TITLE
Add EXTGLOB Support to File Match

### DIFF
--- a/lib/checkie/matcher.rb
+++ b/lib/checkie/matcher.rb
@@ -33,7 +33,7 @@ class Checkie::Matcher
         filename = file[:filename]
         patch = file[:patch]
 
-        if File.fnmatch(match_details[:pattern],filename)
+        if File.fnmatch(match_details[:pattern],filename,File::FNM_EXTGLOB)
           files.add_hunk(file[:status],filename, url: file[:blob_url], additions: file[:additions], deletions: file[:deletions])
 
           # need to break changes into added and removed

--- a/spec/checkie/matcher_spec.rb
+++ b/spec/checkie/matcher_spec.rb
@@ -32,6 +32,15 @@ describe Checkie::Matcher do
       expect(matcher.match).to eq({"readme"=>[["README.md", {additions: 45, deletions: 0, :url=>"https://github.com/Alignable/checkie/blob/dd52731e1f894f53e5972e57255405961ca4ab38/README.md"}]] })
 
     end
+    
+    it 'supports extglob' do
+      instance.add_matching_file("{README,abc}*") do |changes,files|
+        files.added do
+          check(:readme)
+        end
+      end
+      expect(matcher.match).to eq({"readme"=>[["README.md", {additions: 45, deletions: 0, :url=>"https://github.com/Alignable/checkie/blob/dd52731e1f894f53e5972e57255405961ca4ab38/README.md"}]] })
+    end
   end
 
 end


### PR DESCRIPTION
Adds `{a,b}` support to file matching

allows for easier rule reuse by matching more files in a single matching clause. eg

```ruby
matching("*/**/*.{test,spec}.{tsx,ts,jsx,js}") 
```