### PR TITLE
support exclude

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -52,10 +52,14 @@ file_rule :query_preloads,
   "Looks like you're querying an ActiveRecord model, did you check the console for speed and N+1's?"
 
 # Determine the files we want to look for this rule in
-matching("app/models/**.rb") do |changes, files| 
+matching("app/models/**.rb") do |changes, files|
 
   # changes is a match set that contains all lines of the PR app/models/**.rb
   # files is a match set that contains all files of the PR in app/models/**.rb
+
+  # You can also exclude certain files from matching:
+  # matching("app/**/*.rb", exclude: "vendor/**/*")
+  # matching("app/**/*.rb", exclude: ["vendor/**/*", "node_modules/**/*"])
 
   # changes and files all support added, removed and touched matchers
   # each of those matches can take no parameters (were there any?) or

--- a/lib/checkie.rb
+++ b/lib/checkie.rb
@@ -15,8 +15,8 @@ require "#{lib_path}/matcher"
 require "#{lib_path}/poster"
 require "#{lib_path}/runner"
 
-def matching(file_pattern, &block)
-  Checkie::Parser.instance.add_matching_file(file_pattern,&block)
+def matching(file_pattern, exclude: nil, &block)
+  Checkie::Parser.instance.add_matching_file(file_pattern, exclude: exclude, &block)
 end
 
 def matching_ai(file_pattern, rules:, exclude: nil, &block)

--- a/lib/checkie/matcher.rb
+++ b/lib/checkie/matcher.rb
@@ -76,12 +76,15 @@ class Checkie::Matcher
         filename = file[:filename]
         patch = file[:patch]
 
-        if File.fnmatch(match_details[:pattern],filename,File::FNM_EXTGLOB)
-          files.add_hunk(file[:status],filename, url: file[:blob_url], additions: file[:additions], deletions: file[:deletions])
+        # Only consider files matching include pattern
+        next unless File.fnmatch(match_details[:pattern], filename, File::FNM_EXTGLOB)
+        # Skip files matching exclude patterns
+        next if match_details[:exclude] && match_details[:exclude].any? { |p| File.fnmatch(p, filename, File::FNM_EXTGLOB) }
 
-          # need to break changes into added and removed
-          changes.add_patch(filename,patch,  url: file[:blob_url])
-        end
+        files.add_hunk(file[:status],filename, url: file[:blob_url], additions: file[:additions], deletions: file[:deletions])
+
+        # need to break changes into added and removed
+        changes.add_patch(filename,patch,  url: file[:blob_url])
       end
 
       if files.present?

--- a/lib/checkie/parser.rb
+++ b/lib/checkie/parser.rb
@@ -17,15 +17,15 @@ class Checkie::Parser
 
   def add_matching_file(glob_pattern, matching_proc=nil, **opts, &block)
     matching_proc ||= block
-    obj = { pattern: glob_pattern, 
-            matching_proc: matching_proc 
+    obj = { pattern: glob_pattern,
+            matching_proc: matching_proc
           }
+    if opts[:exclude]
+      obj[:exclude] = Array(opts[:exclude])
+    end
     if opts[:ai]
       obj[:rules] = opts[:rules].map do |r|
         @rules_ai[r.to_s]
-      end
-      if opts[:exclude]
-         obj[:exclude] = Array(opts[:exclude])
       end
       @matches_ai << obj
     else

--- a/spec/checkie/matcher_spec.rb
+++ b/spec/checkie/matcher_spec.rb
@@ -41,6 +41,47 @@ describe Checkie::Matcher do
       end
       expect(matcher.match).to eq({"readme"=>[["README.md", {additions: 45, deletions: 0, :url=>"https://github.com/Alignable/checkie/blob/dd52731e1f894f53e5972e57255405961ca4ab38/README.md"}]] })
     end
+
+    describe "exclude" do
+      it "supports exclude pattern" do
+        instance.add_file_rule(:any_file, "You edited a file")
+        instance.add_matching_file("*", exclude: "README*") do |changes,files|
+          files.added do
+            check(:any_file)
+          end
+        end
+
+        # Should not match anything since README.md (the only file) is excluded
+        expect(matcher.match).to eq({})
+      end
+
+      it "supports array of exclude patterns" do
+        instance.add_file_rule(:any_file, "You edited a file")
+        instance.add_matching_file("*", exclude: ["README*"]) do |changes,files|
+          files.added do
+            check(:any_file)
+          end
+        end
+
+        # Should not match anything since README.md (the only file) is excluded
+        expect(matcher.match).to eq({})
+      end
+
+      it "includes files not matching exclude patterns" do
+        instance.add_file_rule(:md_file, "You edited a markdown file")
+        instance.add_matching_file("*", exclude: ["LICENSE*"]) do |changes,files|
+          files.added do
+            check(:md_file)
+          end
+        end
+
+        # Should match README.md since only LICENSE* is excluded
+        result = matcher.match
+        expect(result["md_file"]).not_to be_nil
+        expect(result["md_file"].length).to eq(1)
+        expect(result["md_file"][0][0]).to eq("README.md")
+      end
+    end
   end
 
   describe "#match_ai" do


### PR DESCRIPTION
Support an `exclude:` option in `matching`

Allows us to exclude file globs like:
```ruby
matching("*.{ts,tsx}", exclude: ["*.test.{ts,tsx}", "*.stories.{ts,tsx}"]) do ... end
```